### PR TITLE
feat: add testing job to continuous delivery workflow for Docker images

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -14,12 +14,35 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  TEST_TAG: ghcr.io/${{ github.repository }}:test
   LATEST_TAG: ghcr.io/${{ github.repository }}:latest
   HASH_TAG: ghcr.io/${{ github.repository }}:${{ github.sha }}
 
 jobs:
-  build:
-    name: Publish WolfStar latest image to container registry
+  test:
+    name: Build and Test image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and export for testing
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ${{ env.TEST_TAG }}
+
+      - name: Test image
+        run: |
+          docker run --rm ${{ env.TEST_TAG }} --version
+
+  publish:
+    name: Publish multi-platform image
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -38,20 +61,19 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push by digest
-        id: build
         uses: docker/build-push-action@v6
         with:
-          labels: ${{ steps.meta.outputs.labels }}
           context: .
-          platforms: linux/amd64,linux/arm64
-          outputs: type=image,name=${{ env.IMAGE_NAME }},push=true
+          platforms: linux/amd64,linux/arm64,linux/arm64/v8
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
           tags: |
             ${{ env.LATEST_TAG }}
             ${{ env.HASH_TAG }}


### PR DESCRIPTION
This pull request includes significant changes to the `.github/workflows/continuous-delivery.yml` file to enhance the CI/CD pipeline by adding a testing stage before the publishing stage. The most important changes include the addition of a new job for building and testing the Docker image, and modifications to the existing publish job to depend on the test job.

Enhancements to CI/CD pipeline:

* Added a new `test` job to build and test the Docker image, including steps for setting up Docker Buildx, building the image, and running a test command.
* Modified the `publish` job to depend on the `test` job, ensuring that the image is only published if the tests pass.
* Updated the `publish` job to include the `linux/arm64/v8` platform in the build and push process.
* Simplified the metadata extraction step by renaming it from "Extract metadata (tags, labels) for Docker" to "Extract metadata".