### PR TITLE
chore: update tsdown.config to use deps.skipNodeModulesBundle

### DIFF
--- a/src/lib/moderation/workers/WorkerHandler.ts
+++ b/src/lib/moderation/workers/WorkerHandler.ts
@@ -14,7 +14,6 @@ export class WorkerHandler {
 	private threadId = -1;
 	private queue = new AsyncQueue();
 	private response = new WorkerResponseHandler();
-	private suppressHeartbeatDispatch = false;
 
 	public constructor() {
 		this.spawn();
@@ -39,11 +38,9 @@ export class WorkerHandler {
 
 			return await promise;
 		} catch (error) {
-			this.suppressHeartbeatDispatch = true;
 			await this.restart();
 			throw error;
 		} finally {
-			this.suppressHeartbeatDispatch = false;
 			this.queue.shift();
 		}
 	}
@@ -95,7 +92,7 @@ export class WorkerHandler {
 	}
 
 	private handleWorkerMessage(message: OutgoingPayload) {
-		if (message.type === OutgoingType.Heartbeat && this.suppressHeartbeatDispatch) {
+		if (message.type === OutgoingType.Heartbeat) {
 			this.lastHeartBeat = Date.now();
 			return;
 		}
@@ -104,11 +101,6 @@ export class WorkerHandler {
 	}
 
 	private handleMessage(message: OutgoingPayload) {
-		if (message.type === OutgoingType.Heartbeat) {
-			this.lastHeartBeat = Date.now();
-			return;
-		}
-
 		this.response.resolve(message.id, message);
 	}
 

--- a/tests/lib/moderation/workers/WorkerHandler.test.ts
+++ b/tests/lib/moderation/workers/WorkerHandler.test.ts
@@ -77,7 +77,7 @@ describe('WorkerHandler', () => {
 		};
 
 		await expect(handler.send(given)).resolves.toEqual(expected);
-		expect(handleMessage).toHaveBeenCalledTimes(2);
+		expect(handleMessage).toHaveBeenCalledTimes(1);
 	});
 
 	test('GIVEN non-matching RunRegExp payload THEN resolves with a RegExpMatch payload', async () => {
@@ -93,7 +93,7 @@ describe('WorkerHandler', () => {
 		};
 
 		await expect(handler.send(given)).resolves.toEqual(expected);
-		expect(handleMessage).toHaveBeenCalledTimes(2);
+		expect(handleMessage).toHaveBeenCalledTimes(1);
 	});
 
 	test('GIVEN ReDoS payload THEN rejects with a TimeoutError', async () => {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -95,5 +95,5 @@ export default defineConfig({
 	platform: 'node',
 	tsconfig: 'src/tsconfig.json',
 	treeshake: true,
-	skipNodeModulesBundle: true
+	deps: { skipNodeModulesBundle: true }
 });


### PR DESCRIPTION
Moves `skipNodeModulesBundle` from the top-level config into the `deps` object, removing the deprecation warning introduced in newer tsdown versions.