### PR TITLE
fix(api): exclude guilds from dashboard list after bot leaves

### DIFF
--- a/src/lib/api/utils.ts
+++ b/src/lib/api/utils.ts
@@ -135,6 +135,8 @@ export async function transformOauthGuildsAndUser({ user, guilds }: LoginData): 
 	const { client } = container;
 	const userId = user.id;
 
-	const transformedGuilds = await Promise.all(guilds.map((guild) => transformGuild(client, userId, guild)));
+	const transformedGuilds = (await Promise.all(guilds.map((guild) => transformGuild(client, userId, guild)))).filter(
+		(guild) => guild.wolfstarIsIn && guild.manageable
+	);
 	return { user, transformedGuilds };
 }

--- a/tests/lib/api/utils.test.ts
+++ b/tests/lib/api/utils.test.ts
@@ -1,0 +1,45 @@
+import { transformOauthGuildsAndUser } from '#lib/api/utils';
+import { container } from '@sapphire/framework';
+import { PermissionFlagsBits } from 'discord.js';
+import { client, createGuild } from '../../mocks/MockInstances.js';
+
+describe('transformOauthGuildsAndUser', () => {
+	const user = { id: '242043489611808769', username: 'Owner', discriminator: '0001', avatar: null };
+
+	beforeAll(() => {
+		Object.assign(container, { client });
+	});
+
+	afterEach(() => {
+		client.guilds.cache.clear();
+	});
+
+	it('returns only guilds where the bot is present and the user can manage', async () => {
+		const botGuild = createGuild({ id: '111111111111111111', name: 'Bot Guild' });
+		const oauthGuilds = [
+			{
+				id: botGuild.id,
+				name: botGuild.name,
+				icon: null,
+				owner: true,
+				permissions: PermissionFlagsBits.Administrator.toString()
+			},
+			{
+				id: '222222222222222222',
+				name: 'Left Guild',
+				icon: null,
+				owner: true,
+				permissions: PermissionFlagsBits.Administrator.toString()
+			}
+		];
+
+		const result = await transformOauthGuildsAndUser({ user, guilds: oauthGuilds });
+
+		expect(result.transformedGuilds).toHaveLength(1);
+		expect(result.transformedGuilds![0]).toMatchObject({
+			id: botGuild.id,
+			wolfstarIsIn: true,
+			manageable: true
+		});
+	});
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes WOL-33: servers remained on the profile server list after the bot was removed from a Discord server.

The OAuth transformer (`transformOauthGuildsAndUser`) returned every guild from Discord OAuth, including servers where Wolfstar is no longer present (`wolfstarIsIn: false`). The website displayed these entries, but settings changes failed because guild API routes require the bot to still be in the server.

## Changes

- Filter `transformedGuilds` to only include guilds where `wolfstarIsIn && manageable` before returning OAuth login/sync data.
- Add a unit test covering the filter behavior.

## Testing

- `pnpm test tests/lib/api/utils.test.ts`

## Notes

If the website caches OAuth data client-side, it should still call `POST /oauth/user` with `SYNC_USER` on profile load to pick up removals promptly. This API change ensures the sync response no longer includes left servers even if the frontend does not filter on `wolfstarIsIn`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [WOL-33](https://linear.app/wolfstar-project/issue/WOL-33/bug-it-remains-on-the-server-list-even-after-the-bot-has-left)

<div><a href="https://cursor.com/agents/bc-e1ace209-d3c9-4735-99e7-2e2bf7db4688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1ace209-d3c9-4735-99e7-2e2bf7db4688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

