### PR TITLE
chore: ignore .claude/state folder in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ plans/
 
 # Profiler data
 *.0x
+
+# Ignore the .claude/state folder
+.claude/state


### PR DESCRIPTION
## Summary

Adds `.claude/state` to `.gitignore` so Claude Code session state files are not tracked in the repository.

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (no functional changes)
- [ ] Cosmetic (formatting, typos, etc.)
- [ ] Documentation
- [ ] Workflow / CI

## Test Plan

- [x] Verified `.gitignore` syntax is correct
- [x] Confirmed only `.gitignore` is changed (3 lines added)

## Pre-flight Checklist

- [x] My code follows the project style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (N/A — `.gitignore` only)
- [x] New and existing unit tests pass locally with my changes (N/A — `.gitignore` only)
