### PR TITLE
ci: inherit native per-arch runners from reusable publish workflow

### DIFF
--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -22,7 +22,3 @@ jobs:
         name: Publish WolfStar Latest image to GHCR
         uses: wolfstar-project/.github/.github/workflows/reusable-publish-image.yml@main
         secrets: inherit
-        with:
-            enablePlatforms: true
-            platforms: >-
-                [{"platform": "linux/amd64", "runner": "ubuntu-latest"}, {"platform": "linux/arm64", "runner": "ubuntu-latest"}]

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -21,8 +21,5 @@ jobs:
         uses: wolfstar-project/.github/.github/workflows/reusable-publish-image.yml@main
         secrets: inherit
         with:
-            enablePlatforms: true
             commitHash: ${{ github.event.inputs.commit }}
             tag: stable
-            platforms: >-
-                [{"platform": "linux/amd64", "runner": "ubuntu-latest"}, {"platform": "linux/arm64", "runner": "ubuntu-latest"}]


### PR DESCRIPTION
## Cosa cambia

Rimuove l'override `platforms` (e il flag `enablePlatforms`, ormai non più usato dal reusable workflow) dalla chiamata a `reusable-publish-image.yml`: il workflow eredita così i runner di default, ora nativi per architettura (Blacksmith amd64/arm64 — vedi wolfstar-project/.github#35).

## Perché

Con l'override attuale entrambe le piattaforme vengono buildate su `ubuntu-latest` (amd64): la build arm64 passa per l'emulazione QEMU (lenta) e le action `useblacksmith/*` vanno in fallback sul builder locale. Con i runner nativi ogni architettura è compilata su hardware nativo, come da [guida Docker multi-platform](https://docs.docker.com/build/building/multi-platform/).

La modifica è sicura in qualunque ordine di merge rispetto a wolfstar-project/.github#35: anche i vecchi default funzionano senza override.

https://claude.ai/code/session_01Xv1EAagQkhuCRGY584Kuua

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Captured the Before artifact showing initial enablePlatforms: true for both workflows.
- Copied or prepared the validation script at trex-artifacts/validate\_workflow\_contract.py to verify the workflow contract.
- Captured the After artifact showing has\_enablePlatforms: False and has\_platforms: False for both workflows, and publish-stable retaining stable\_has\_commitHash: True and stable\_tag\_value: "stable".

<a href="https://app.greptile.com/trex/runs/13117458/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Trigger as GitHub trigger
participant Caller as wolfstar workflow
participant Reusable as reusable-publish-image.yml
participant Runner as Default per-arch runner
participant GHCR as GHCR

Trigger->>Caller: push/workflow_dispatch
Caller->>Reusable: uses workflow with inherited secrets
Note over Caller,Reusable: No caller-level platforms override
Reusable->>Runner: select default platform runners
Runner->>Reusable: build image for configured architectures
Reusable->>GHCR: publish image tag
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Trigger as GitHub trigger
participant Caller as wolfstar workflow
participant Reusable as reusable-publish-image.yml
participant Runner as Default per-arch runner
participant GHCR as GHCR

Trigger->>Caller: push/workflow_dispatch
Caller->>Reusable: uses workflow with inherited secrets
Note over Caller,Reusable: No caller-level platforms override
Reusable->>Runner: select default platform runners
Runner->>Reusable: build image for configured architectures
Reusable->>GHCR: publish image tag
```

</a>

<sub>Reviews (1): Last reviewed commit: ["ci: inherit native per-arch runners from..."](https://github.com/wolfstar-project/wolfstar/commit/30ff65c924964f5beb4f45b440d41a1a7bc29096) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41486026)</sub>

<!-- /greptile_comment -->