### PR TITLE
build(docker): pin base stage to $BUILDPLATFORM for cross-compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #   Base Stage     #
 # ================ #
 
-FROM node:24-alpine AS base
+FROM --platform=$BUILDPLATFORM node:24-alpine AS base
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Cosa cambia

Pinna lo stage `base` del Dockerfile a `--platform=$BUILDPLATFORM`, come indicato nella sezione [cross-compilation](https://docs.docker.com/build/building/multi-platform/#cross-compilation) della guida Docker: lo stage di build (`pnpm install` + `pnpm run build` + `prisma:generate`) gira sempre sull'architettura nativa del builder, mai sotto emulazione, indipendentemente dalla strategia di runner usata in CI. Lo stage `runner` (finale) resta senza pin, quindi continua a targettare la piattaforma di build effettiva — dove infatti viene già rieseguito `pnpm install --prod`, che ricompila correttamente eventuali binding nativi per quella architettura.

Con i runner Blacksmith nativi per-arch introdotti in wolfstar-project/.github#35 questo è oggi un no-op (BUILDPLATFORM coincide già con la piattaforma target in ogni job della matrix), ma allinea il Dockerfile alla pratica raccomandata e lo mette al riparo nel caso si torni in futuro a un builder singolo multi-platform.

https://claude.ai/code/session_01Xv1EAagQkhuCRGY584Kuua

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Attempted to run Docker and Buildx commands against the final stage to exercise BuildKit, but the environment had command-not-found errors for Docker tooling, blocking execution.
- Ran a tooling probe to check for docker, podman, buildah, nerdctl, buildctl, and the system architecture, and confirmed the host is x86\_64 with no container build/run tooling installed.
- Created a minimal harness that preserves the pinned base and runner stage structure using FROM --platform=$BUILDPLATFORM node:24-alpine AS base followed by FROM base AS runner, but could not build or inspect it due to the lack of Docker and related tooling in the environment.
- Compared the base/build-stage platform resolution before and after the change, noting that the before state resolves to linux/arm64 for a linux/arm64 target, while the after state resolves to linux/amd64 on the native builder.

<a href="https://app.greptile.com/trex/runs/13181322/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant BuildKit
participant Base as base stage<br/>--platform=$BUILDPLATFORM
participant Builder as builder stage
participant Runner as runner stage
BuildKit->>Base: Resolve node:24-alpine for BUILDPLATFORM
Base->>Builder: FROM base AS builder
Builder->>Builder: pnpm install + prisma generate + build
Base->>Runner: FROM base AS runner
Builder->>Runner: COPY dist/node_modules/env
Runner->>BuildKit: Final image inherits BUILDPLATFORM base
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant BuildKit
participant Base as base stage<br/>--platform=$BUILDPLATFORM
participant Builder as builder stage
participant Runner as runner stage
BuildKit->>Base: Resolve node:24-alpine for BUILDPLATFORM
Base->>Builder: FROM base AS builder
Builder->>Builder: pnpm install + prisma generate + build
Base->>Runner: FROM base AS runner
Builder->>Runner: COPY dist/node_modules/env
Runner->>BuildKit: Final image inherits BUILDPLATFORM base
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ADockerfile%3A45%0A**Final%20stage%20still%20pinned**%0A%60runner%60%20is%20built%20%60FROM%20base%60%2C%20so%20it%20starts%20from%20the%20%60%24BUILDPLATFORM%60%20image%20chosen%20on%20line%205.%20In%20a%20single-builder%20multi-platform%20build%2C%20the%20final%20image%20is%20produced%20for%20the%20builder%20architecture%20instead%20of%20%60%24TARGETPLATFORM%60%2C%20while%20the%20PR%20intends%20only%20the%20build%20steps%20to%20avoid%20emulation.%20Split%20the%20runtime%20stage%20from%20an%20unpinned%20%60node%3A24-alpine%60%20base%2C%20or%20keep%20only%20the%20build%20stage%20on%20the%20pinned%20base.%0A%0A&repo=wolfstar-project%2Fwolfstar&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ADockerfile%3A45%0A**Final%20stage%20still%20pinned**%0A%60runner%60%20is%20built%20%60FROM%20base%60%2C%20so%20it%20starts%20from%20the%20%60%24BUILDPLATFORM%60%20image%20chosen%20on%20line%205.%20In%20a%20single-builder%20multi-platform%20build%2C%20the%20final%20image%20is%20produced%20for%20the%20builder%20architecture%20instead%20of%20%60%24TARGETPLATFORM%60%2C%20while%20the%20PR%20intends%20only%20the%20build%20steps%20to%20avoid%20emulation.%20Split%20the%20runtime%20stage%20from%20an%20unpinned%20%60node%3A24-alpine%60%20base%2C%20or%20keep%20only%20the%20build%20stage%20on%20the%20pinned%20base.%0A%0A&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22wolfstar-project%2Fwolfstar%22%20on%20the%20existing%20branch%20%22build%2Fpin-buildplatform%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22build%2Fpin-buildplatform%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ADockerfile%3A45%0A**Final%20stage%20still%20pinned**%0A%60runner%60%20is%20built%20%60FROM%20base%60%2C%20so%20it%20starts%20from%20the%20%60%24BUILDPLATFORM%60%20image%20chosen%20on%20line%205.%20In%20a%20single-builder%20multi-platform%20build%2C%20the%20final%20image%20is%20produced%20for%20the%20builder%20architecture%20instead%20of%20%60%24TARGETPLATFORM%60%2C%20while%20the%20PR%20intends%20only%20the%20build%20steps%20to%20avoid%20emulation.%20Split%20the%20runtime%20stage%20from%20an%20unpinned%20%60node%3A24-alpine%60%20base%2C%20or%20keep%20only%20the%20build%20stage%20on%20the%20pinned%20base.%0A%0A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.&repo=wolfstar-project%2Fwolfstar&uid=108079&ts=1783075500&sig=40e62016eb1192ce3a710ca2caf31ad030e4c5adcfb6352c789ad2b045f00060&pr=221&platform=github&fid=520609ef-a170-48f1-94cb-a1853487da4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloudDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"><img alt="Fix All in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Dockerfile:45
**Final stage still pinned**
`runner` is built `FROM base`, so it starts from the `$BUILDPLATFORM` image chosen on line 5. In a single-builder multi-platform build, the final image is produced for the builder architecture instead of `$TARGETPLATFORM`, while the PR intends only the build steps to avoid emulation. Split the runtime stage from an unpinned `node:24-alpine` base, or keep only the build stage on the pinned base.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["build(docker): pin base stage to $BUILDP..."](https://github.com/wolfstar-project/wolfstar/commit/48b7370525561ab0dfdcce516709e53e951fb576) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41613436)</sub>

<!-- /greptile_comment -->