### PR TITLE
docs: Update README badges and improve documentation formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,18 @@ Link][invite-link] · [Support Server][discord-link] ·
 
 <!-- SHIELD GROUP -->
 
-[![][github-release-shield]][github-release-link]
-[![][github-releasedate-shield]][github-releasedate-link]<br/>
-[![][discord-shield]][discord-link] [![][codecov-shield]][codecov-link]
-[![][github-contributors-shield]][github-contributors-link]<br/>
-[![][github-forks-shield]][github-forks-link]
-[![][github-stars-shield]][github-stars-link]
-[![][github-issues-shield]][github-issues-link]
-[![][github-license-shield]][github-license-link]<br>
-[![][pr-welcome-shield]][pr-welcome-link]
+[![GitHub latest release badge][github-release-shield]][github-release-link]
+[![GitHub last commit badge][github-last-commit-shield]][github-last-commit-link]<br/>
+[![Discord community badge][discord-shield]][discord-link]
+[![Codecov coverage badge][codecov-shield]][codecov-link]
+[![GitHub contributors badge][github-contributors-shield]][github-contributors-link]<br/>
+[![GitHub forks badge][github-forks-shield]][github-forks-link]
+[![GitHub stars badge][github-stars-shield]][github-stars-link]
+[![GitHub issues badge][github-issues-shield]][github-issues-link]
+[![GitHub license badge][github-license-shield]][github-license-link]<br>
+[![PRs welcome badge][pr-welcome-shield]][pr-welcome-link]
 
-**Share WolfStar Repository**
+### Share WolfStar Repository
 
 [![][share-linkedin-shield]][share-linkedin-link]
 [![][share-reddit-shield]][share-reddit-link]
@@ -191,7 +192,7 @@ Thank you for your support!
 
 <div align="right">
 
-[![][back-to-top]](#readme-top)
+[![Back to top][back-to-top]](#readme-top)
 
 </div>
 
@@ -215,46 +216,46 @@ Copyright © 2024 [WolfStar][profile-link]. <br /> This project is
 [blog]: https://blog.wolfstar.rocks
 [codecov-link]: https://codecov.io/gh/wolfstar-project/wolfstar
 [codecov-shield]:
-  https://img.shields.io/codecov/c/github/wolfstar-project/wolfstar?labelColor=black&style=flat-square&logo=codecov&logoColor=white
+  https://shieldcn.dev/codecov/github/wolfstar-project/wolfstar?variant=branded
 [codespaces-link]: https://codespaces.new/wolfstar-project/wolfstar
 [codespaces-shield]: https://github.com/codespaces/badge.svg
 [discord-link]: https://discord.gg/gqAnRyUXG8
 [discord-shield]:
-  https://img.shields.io/discord/830481105261821952?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=flat-square
+  https://shieldcn.dev/discord/830481105261821952?variant=branded
 [discord-shield-badge]:
   https://img.shields.io/discord/1127171173982154893?color=5865F2&label=discord&labelColor=black&logo=discord&logoColor=white&style=for-the-badge
 [github-contributors-link]:
   https://github.com/wolfstar-project/wolfstar/graphs/contributors
 [github-contributors-shield]:
-  https://img.shields.io/github/contributors/wolfstar-project/wolfstar?color=c4f042&labelColor=black&style=flat-square
+  https://shieldcn.dev/github/contributors/wolfstar-project/wolfstar?variant=branded
 [github-forks-link]:
   https://github.com/wolfstar-project/wolfstar/network/members
 [github-forks-shield]:
-  https://img.shields.io/github/forks/wolfstar-project/wolfstar?color=8ae8ff&labelColor=black&style=flat-square
+  https://shieldcn.dev/github/forks/wolfstar-project/wolfstar?variant=branded
 [github-issues-link]: https://github.com/wolfstar-project/wolfstar/issues
 [github-issues-shield]:
-  https://img.shields.io/github/issues/wolfstar-project/wolfstar?color=ff80eb&labelColor=black&style=flat-square
+  https://shieldcn.dev/github/issues/wolfstar-project/wolfstar?variant=branded
+[github-last-commit-link]: https://github.com/wolfstar-project/wolfstar/commits
+[github-last-commit-shield]:
+  https://shieldcn.dev/github/last-commit/wolfstar-project/wolfstar?variant=branded
 [github-license-link]:
   https://github.com/wolfstar-project/wolfstar/blob/main/LICENSE
 [github-license-shield]:
-  https://img.shields.io/badge/license-apache%202.0-white?labelColor=black&style=flat-square
+  https://shieldcn.dev/github/license/wolfstar-project/wolfstar?variant=branded
 [github-project-link]: https://github.com/wolfstar-project/wolfstar/projects
 [github-release-link]: https://github.com/wolfstar-project/wolfstar/releases
 [github-release-shield]:
-  https://img.shields.io/github/v/release/wolfstar-project/wolfstar?color=369eff&labelColor=black&logo=github&style=flat-square
-[github-releasedate-link]: https://github.com/wolfstar-project/wolfstar/releases
-[github-releasedate-shield]:
-  https://img.shields.io/github/release-date/wolfstar-project/wolfstar?labelColor=black&style=flat-square
+  https://shieldcn.dev/github/release/wolfstar-project/wolfstar?variant=branded
 [github-stars-link]:
   https://github.com/wolfstar-project/wolfstar/network/stargazers
 [github-stars-shield]:
-  https://img.shields.io/github/stars/wolfstar-project/wolfstar?color=ffcb47&labelColor=black&style=flat-square
+  https://shieldcn.dev/github/stars/wolfstar-project/wolfstar?variant=branded
 [issues-link]:
   https://img.shields.io/github/issues/wolfstar-project/wolfstar.svg?style=flat
 [official-site]: https://wolfstar.rocks
 [pr-welcome-link]: https://github.com/wolfstar-project/wolfstar/pulls
 [pr-welcome-shield]:
-  https://img.shields.io/badge/🤯_pr_welcome-%E2%86%92-ffcb47?labelColor=black&style=for-the-badge
+  https://shieldcn.dev/badge/PRs-welcome-ffcb47?variant=branded
 [profile-link]: https://github.com/wolfstar
 [set-up - refer to contributing.md]:
   https://github.com/wolfstar-project/.github/blob/main/.github/CONTRIBUTING.md


### PR DESCRIPTION
## Summary
Updated the README.md file to improve badge consistency, add descriptive labels, and enhance overall documentation formatting.

## Key Changes
- **Badge Provider Migration**: Migrated all shield badges from `img.shields.io` to `shieldcn.dev` with the `variant=branded` parameter for consistent styling
- **Improved Badge Labels**: Added descriptive text labels to all badge references (e.g., "GitHub latest release badge", "Discord community badge") for better clarity
- **Badge Updates**: 
  - Replaced "GitHub release date" badge with "GitHub last commit" badge for more relevant information
  - Updated badge URLs to use the new provider's endpoints
- **Formatting Improvements**:
  - Changed "Share WolfStar Repository" from bold text to a proper heading (### level)
  - Added descriptive text to the "back to top" link for better accessibility
- **Reference Link Updates**: Updated all badge reference definitions in the links section to point to the new badge provider URLs

## Notable Details
- All badge functionality remains the same; only the visual provider and styling have been updated
- The new badge provider (`shieldcn.dev`) appears to offer consistent branded styling across all badges
- Documentation clarity is improved through explicit badge descriptions in alt text

https://claude.ai/code/session_01R1MGcQggWVmQe57RmjPTjt

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

This documentation-only PR is safe to merge.

No blocking functional, security, or repository-contract issues were identified in the changed file.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The formatter proof confirms that the README.md formatter check ran and exited with code 0.
- The README inspection proof shows badge alt text examples such as GitHub latest release badge, GitHub last commit badge, and Discord community badge, along with share section labels, back-to-top anchors, and branded shield links.

<a href="https://app.greptile.com/trex/runs/13991640/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: switch README badges to shieldcn.d..."](https://github.com/wolfstar-project/wolfstar/commit/e2b8a560a10b29a738c15f3d3118f37a742dffe2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43316087)</sub>

<!-- /greptile_comment -->