### PR TITLE
docs: remove align="right" from Online Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ instructions.
 
 </div>
 
-<div id="-online-development" align="right">
+<div id="-online-development">
 
 ## 💻 Online Development
 


### PR DESCRIPTION
## Summary

Removes the unnecessary `align="right"` attribute from the Online Development section anchor in `README.md`. Other README section anchors do not use inline alignment, so this keeps formatting consistent.

## Related Issue

#XXXX (N/A — small documentation fix)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor
- [x] Documentation
- [ ] Workflow / CI

## Test Plan

- [x] Verified the README renders correctly without the `align="right"` attribute
- [x] Confirmed no other README sections use inline `align` on section anchors

## Pre-flight Checklist

- [x] Changes are limited to documentation
- [x] Commit message follows project conventions
- [x] Branch is based on `main`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The change is limited to one README attribute removal and matches the stated documentation intent.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Confirmed the README anchor was incorrect in the before state, as shown by readme-anchor-consistency-01-before.log.
- Confirmed the README anchor was corrected in the after state, with the line now containing the proper anchor and a PASS result, per readme-anchor-consistency-02-after.log.
- Verified there are no section-anchor alignment issues, since the readme-section-anchor-align-scan.log reported no matches.
- Noted an auxiliary JavaScript artifact was uploaded to support the proof, captured as an additional artifact with type text/javascript.

<a href="https://app.greptile.com/trex/runs/14014059/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: remove align=&quot;right&quot; from Online D..."](https://github.com/wolfstar-project/wolfstar/commit/3327437107ee4c545ecdb1e9ac26fe66df85b52e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43358551)</sub>

<!-- /greptile_comment -->