### PR TITLE
ci: right-size Unit tests runner to 8 vCPU

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -65,7 +65,7 @@ jobs:
 
     test:
         name: Unit tests
-        runs-on: blacksmith-4vcpu-ubuntu-2404
+        runs-on: blacksmith-8vcpu-ubuntu-2404
 
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Right-sizes the `Unit tests` job in the `ci` workflow (`.github/workflows/continuous-integration.yml`) based on the last 30 days of observed runner metrics.

### Test before applying

**`Unit tests`: `blacksmith-4vcpu-ubuntu-2404` -> `blacksmith-8vcpu-ubuntu-2404`** (low confidence)

The job is CPU-bound during bursts: 89% 95th-percentile CPU, 98% 99th-percentile CPU, and it already uses all 4 available cores at its peak. Doubling to 8 vCPU gives it headroom for the parallel test phase.

- Projected wall-time change: about -9% overall (p50 ~24s -> ~21.6s, p95 ~38.7s -> ~36.2s).
- Estimated cost impact: about +$0.34/month (~50 runs/month).
- Confidence is low and the wall-time model projects only a modest gain, so this is worth validating on a few runs before treating it as settled. If the speedup doesn't materialize, reverting to 4 vCPU is a one-line change.

Sample runs:
- Median run: https://app.blacksmith.sh/wolfstar-project/runs/28883939919/jobs/85679131665?tab=metrics
- Slow run (p95): https://app.blacksmith.sh/wolfstar-project/runs/30126084615/jobs/89589805238?tab=metrics

```yaml
    test:
        name: Unit tests
        runs-on: blacksmith-8vcpu-ubuntu-2404
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only increases CPU capacity for the existing Unit tests job without changing its platform or execution steps.

The workflow retains the same Ubuntu 24.04 x86 runner family, setup actions, dependency installation, Prisma generation, test command, and coverage upload; only the runner’s vCPU allocation changes.
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: right-size Unit tests runner to 8 vC..."](https://github.com/wolfstar-project/wolfstar/commit/29f95e5eb87fdef85e6243b170818036d07e3782) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47221631)</sub>

<!-- /greptile_comment -->