### PR TITLE
Revert "ci: migrate GitHub Actions runners from Blacksmith to Depot"

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
     code:
-        runs-on: depot-ubuntu-24.04-arm-4
+        runs-on: blacksmith-4vcpu-ubuntu-2404-arm
 
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -22,5 +22,3 @@ jobs:
         name: Publish WolfStar Latest image to GHCR
         uses: wolfstar-project/.github/.github/workflows/reusable-publish-image.yml@main
         secrets: inherit
-        with:
-            depotProject: 10f7gg2mqd

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
     lint:
         name: Lint project
-        runs-on: depot-ubuntu-24.04-arm-4
+        runs-on: blacksmith-4vcpu-ubuntu-2404-arm
 
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -42,7 +42,7 @@ jobs:
 
     build:
         name: Build project
-        runs-on: depot-ubuntu-24.04-4
+        runs-on: blacksmith-4vcpu-ubuntu-2404
 
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -65,7 +65,7 @@ jobs:
 
     test:
         name: Unit tests
-        runs-on: depot-ubuntu-24.04-8
+        runs-on: blacksmith-8vcpu-ubuntu-2404
 
         steps:
             - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -23,4 +23,3 @@ jobs:
         with:
             commitHash: ${{ github.event.inputs.commit }}
             tag: stable
-            depotProject: 10f7gg2mqd

--- a/.github/workflows/update-tlds.yml
+++ b/.github/workflows/update-tlds.yml
@@ -8,7 +8,7 @@ on:
 jobs:
     UpdateTLDs:
         name: Update TLD's
-        runs-on: depot-ubuntu-24.04-4
+        runs-on: blacksmith-4vcpu-ubuntu-2404
         steps:
             - name: Checkout Project
               uses: actions/checkout@v7


### PR DESCRIPTION
Reverts wolfstar-project/wolfstar#227

Depot runners were hitting a high failure rate (job never starts, "lost communication with the server") traced back to a concurrency limit on our Depot org, and Depot declined our open-source sponsorship request. Reverting to Blacksmith, which this project ran on without issues before.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar/pr/228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787934095&installation_model_id=425462&pr_number=228&repository=wolfstar-project%2Fwolfstar&return_to=https%3A%2F%2Fgithub.com%2Fwolfstar-project%2Fwolfstar%2Fpull%2F228&signature=1ae5dd6f0066b4e981a11ba8a8c7201cfd6693a2fb59f98c70f838187ebf0470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The changes appear safe to merge, with no concrete changed-code failures identified.

The runner substitutions restore labels and architecture assignments previously used by these workflows, while the publishing changes cleanly revert the Depot-specific input.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before and after states were compared: the before log shows five Depot runner labels and the after log shows five Blacksmith labels, with non\_blacksmith\_direct\_runner\_count reported as 0.
- Runtime validation completed successfully, with Prisma generation and build exiting with code 0 and Vitest reporting all tests passing (35/35 files, 341/341 tests).
- CI command preservation was verified, with the preservation log reporting commands\_identical=true for every CI run.
- Artifacts were collected to support review, including the setup-and-run-script.sh and several CI logs.

<a href="https://app.greptile.com/trex/runs/16421272/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;ci: migrate GitHub Actions runne..."](https://github.com/wolfstar-project/wolfstar/commit/4933ba81bcd0763ca102c1615e7d6feef8497397) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48379623)</sub>

<!-- /greptile_comment -->