### PR TITLE
ci: migrate from Blacksmith to GitHub-hosted runners

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
     code:
-        runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+        runs-on: ubuntu-24.04-arm
 
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -22,7 +22,7 @@ permissions:
 jobs:
     lint:
         name: Lint project
-        runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+        runs-on: ubuntu-24.04-arm
 
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -42,7 +42,7 @@ jobs:
 
     build:
         name: Build project
-        runs-on: blacksmith-4vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
 
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -65,7 +65,7 @@ jobs:
 
     test:
         name: Unit tests
-        runs-on: blacksmith-8vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
 
         steps:
             - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/update-tlds.yml
+++ b/.github/workflows/update-tlds.yml
@@ -8,7 +8,7 @@ on:
 jobs:
     UpdateTLDs:
         name: Update TLD's
-        runs-on: blacksmith-4vcpu-ubuntu-2404
+        runs-on: ubuntu-latest
         steps:
             - name: Checkout Project
               uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- Migrate CI/CD workflows off Blacksmith runners to GitHub-hosted runners
- `blacksmith-4vcpu-ubuntu-2404` / `blacksmith-8vcpu-ubuntu-2404` -> `ubuntu-latest`
- `blacksmith-4vcpu-ubuntu-2404-arm` / `blacksmith-8vcpu-ubuntu-2404-arm` -> `ubuntu-24.04-arm`

## Test plan
- [ ] CI passes on this PR with the new runner labels

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wolfstar-project/codesmith/wolfstar/pr/231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The migration validation compared all five workflow runner labels before and after the change, showing that the prior Blacksmith labels failed GitHub-hosted validation while ubuntu-24.04-arm and ubuntu-latest passed.
- GitHub check runs for commit beb590e completed with successful Lint project, Build project, Unit tests, and autofix (code) jobs, confirming the updated runners scheduled and finished.
- Before capture, HEAD^ had five invalid-for-GitHub-hosted Blacksmith labels and exited 1; after capture, HEAD has ubuntu-24.04-arm for ARM jobs and ubuntu-latest for x64 jobs, and the validator exited 0.
- GitHub check-run evidence shows successful completed executions for all changed workflow jobs, including both ARM-label jobs.

<a href="https://app.greptile.com/trex/runs/16918869/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: migrate from Blacksmith to GitHub-ho..."](https://github.com/wolfstar-project/wolfstar/commit/beb590e805beb25a0a523ef4c3331b79636a4e62) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49386045)</sub>

<!-- /greptile_comment -->