### PR TITLE
chore(docs): update AGENTS.md to reflect recent changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,14 @@ Discord bot built on **Sapphire Framework** (discord.js). TypeScript, PostgreSQL
 - Existing structure tests: `tests/lib/database/settings/structures/PermissionNodeManager.test.ts`
 - vitest globals enabled (no explicit imports for `describe`, `it`, `expect`)
 
+## Localization
+
+- **Tooling:** [Tolgee](https://tolgee.io/) (migrated from Crowdin)
+- **Config:** `.tolgeerc.cjs` (project id, locale↔Tolgee-tag mapping, push file list, pull output path)
+- **Locale files:** `src/languages/{discordLocale}/{namespace}.json` (e.g. `en-US/globals.json`, `en-US/commands/admin.json`)
+- **Pull remap script:** `scripts/tolgee-pull-remap.ts` — moves `tolgee pull` output from `.tolgee-pull/{tolgeeTag}/` into the matching `src/languages/{discordLocale}/` directory
+- Requires `TOLGEE_API_KEY` in the environment for push/pull; never commit it
+
 ## Plan Directory
 
 `.atlas/plans/*`
@@ -73,6 +81,8 @@ InfluxDB and Redis in `compose.dev.yaml` are optional. For local dev without Inf
 | Build                    | `pnpm build`                      |
 | Dev (watch + start)      | `pnpm dev`                        |
 | Start (production build) | `INFLUX_ENABLED=false pnpm start` |
+| Pull translations        | `pnpm tolgee:pull`                |
+| Push translations        | `pnpm tolgee:push`                |
 
 Unit tests import `#lib/setup` via `tests/vitest.setup.ts`, which loads `src/lib/setup/prisma.ts` and constructs `PrismaPg` from `process.env.DATABASE_URL`, so tests require a `DATABASE_URL`/PostgreSQL connection. They do not require a `DISCORD_TOKEN` because mocked Discord is provided by `tests/vitest.setup.ts` and `tests/mocks/MockInstances.ts`. Full bot startup requires a valid `DISCORD_TOKEN` in `src/.env` (or `src/.env.local`, gitignored).
 


### PR DESCRIPTION
## Summary

Weekly AGENTS.md maintenance review. Checked all PRs merged into `main` in the last 7 days:

- #231 ci: migrate from Blacksmith to GitHub-hosted runners
- #222 fix(deps): update all non-major dependencies
- #229 chore(i18n): migrate localization tooling from Crowdin to Tolgee
- #228 / #227 Depot runner migration + revert
- #219 fix(deps): update dependency i18next to v26
- #225 chore(deps): update actions/setup-node action to v7

Only #229 introduced anything AGENTS.md needed to reflect: it's a real tooling/convention change (new config file, new npm scripts, new locale-sync workflow), not just a version bump. The rest are CI-runner or dependency-version churn with no impact on documented architecture, conventions, or commands.

## Changes

- Added a **Localization** section documenting the Tolgee tooling (`.tolgeerc.cjs` config, `src/languages/{discordLocale}/{namespace}.json` layout, the `scripts/tolgee-pull-remap.ts` remap step, and the `TOLGEE_API_KEY` requirement).
- Added `pnpm tolgee:pull` / `pnpm tolgee:push` rows to the Common commands table.

No existing content was removed — AGENTS.md had no prior Crowdin references to clean up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KwXsoMrGdYtJKaw9gshwgS)_

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The documented localization workflow agrees with the configured English Tolgee tag and its remapping behavior.

The checked translation push and pull/remap path completed successfully with the updated `en-US` tag, and no defects remain.

**Files Needing Attention:** None.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the isolated Tolgee localization contract test with the review-authored Node harness to compare the parent and updated worktrees.
- Before the PR update, the harness recorded tolgee push --languages en and remapped a generated .tolgee-pull/en fixture into src/languages/en-US.
- After the PR update, the harness recorded tolgee push --languages en-US and remapped a generated .tolgee-pull/en-US fixture into the same src/languages/en-US directory.
- The before/after evidence and the exact review-authored harness source were saved under trex-artifacts, documenting the mapping changes.

<a href="https://app.greptile.com/trex/runs/17421101/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;main&#39; into claude/elegant-..."](https://github.com/wolfstar-project/wolfstar/commit/87035c8bdb11b9f9b147a7274ab3b29dac98e404) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50410307)</sub>

<!-- /greptile_comment -->