### PR TITLE
ci(i18n): add scheduled Tolgee translation sync workflow

### DIFF
--- a/.github/workflows/tolgee-sync.yml
+++ b/.github/workflows/tolgee-sync.yml
@@ -1,0 +1,59 @@
+name: Tolgee Translation Sync
+
+on:
+    workflow_dispatch:
+    schedule:
+        # Every day at 02:00 UTC
+        - cron: '0 2 * * *'
+
+concurrency:
+    group: tolgee-sync
+    cancel-in-progress: false
+
+jobs:
+    SyncTranslations:
+        name: Sync translations from Tolgee
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - name: Checkout Project
+              uses: actions/checkout@v7
+              with:
+                  token: ${{ secrets.WOLFSTAR_TOKEN }}
+                  fetch-depth: 0
+            - name: Install pnpm and Node.js v24
+              uses: pnpm/setup@v2
+              with:
+                  runtime: node@24
+                  cache: true
+                  # Install is run explicitly below so it can skip lifecycle scripts
+                  install: false
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile --ignore-scripts
+            - name: Pull translations from Tolgee
+              env:
+                  TOLGEE_API_KEY: ${{ secrets.TOLGEE_API_KEY }}
+              # `pnpm tolgee:pull` runs the CLI (config: .tolgeerc.cjs) and then
+              # scripts/tolgee-pull-remap.ts, which remaps Tolgee language tags
+              # (es, pt, zh-Hans, …) onto the Discord locale directories.
+              run: pnpm tolgee:pull
+            - name: Commit any changes and create a pull request
+              env:
+                  GITHUB_TOKEN: ${{ secrets.WOLFSTAR_TOKEN }}
+              run: |
+                  git add src/languages;
+                  if git diff-index --quiet HEAD --; then
+                    echo "No translation changes to commit, exiting with code 0"
+                    exit 0;
+                  else
+                    git remote set-url origin "https://${GITHUB_TOKEN}:x-oauth-basic@github.com/${GITHUB_REPOSITORY}.git";
+                    # Commit as the account behind WOLFSTAR_TOKEN
+                    git config --local user.name "wolfstarbot";
+                    git config --local user.email "169603024+wolfstarbot@users.noreply.github.com";
+                    git checkout -b tolgee-sync/$(date +%F-%H-%M);
+                    git commit -sam "chore(i18n): update translations from Tolgee";
+                    git push --set-upstream origin $(git rev-parse --abbrev-ref HEAD);
+                    gh pr create -t "chore(i18n): update translations from Tolgee" -b "*bleep bloop* I synced the translations from Tolgee" -B main;
+                  fi


### PR DESCRIPTION
## What

Adds `.github/workflows/tolgee-sync.yml`: a daily (02:00 UTC) + `workflow_dispatch` job that pulls translations from Tolgee and opens a PR when locale files change.

## Why

Translations edited in Tolgee currently only land in the repo when someone runs `pnpm tolgee:pull` locally. This automates the round trip.

## Notes for reviewers

- **Uses `pnpm tolgee:pull`, not a raw `tolgee pull`.** The CLI stages into `.tolgee-pull/` per `.tolgeerc.cjs`, and `scripts/tolgee-pull-remap.ts` then remaps Tolgee language tags (`es`, `pt`, `zh-Hans`, …) onto the Discord locale directories (`es-ES`, `pt-BR`, `zh-CN`). Calling the CLI directly would bypass the remap.
- **`pnpm/setup@v2`** replaces the `pnpm/action-setup` + `actions/setup-node` pair. `runtime: node@24` is explicit because the repo has no `devEngines.runtime`; the pnpm version still comes from `packageManager`. `install: false` keeps the install as its own step so it can pass `--ignore-scripts` (skips `prepare: husky`).
- **`WOLFSTAR_TOKEN`** is used for checkout, push and `gh pr create` so the generated PR triggers CI (a `GITHUB_TOKEN` PR would not). Commits are authored by `wolfstarbot`.
- `concurrency: tolgee-sync` prevents a manual run and the cron run from opening duplicate PRs.

## Required before this works

The `TOLGEE_API_KEY` repository secret must be set (Project API Key or PAT). Without it the pull step fails.

<!-- greptile_comment -->

<details><summary><h3>Confidence Score: 3/5</h3></summary>

Not safe to merge until the translation branch is based on `main` and privileged actions are pinned to immutable revisions.

The main translation-update path can create pull requests containing unrelated commits when manually run from another ref. Separately, mutable action references can execute changed upstream code with repository-write and Tolgee credentials.

**Files Needing Attention:** .github/workflows/tolgee-sync.yml
</details>

<details open><summary><h3>Security Review</h3></summary>

The workflow grants repository write permissions and provides `WOLFSTAR_TOKEN` and `TOLGEE_API_KEY` to workflow steps. `actions/checkout@v7` and `pnpm/setup@v2` are mutable tags, so an upstream tag update could alter code that runs with those credentials. Pin both actions to reviewed full commit SHAs.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the Git ref-resolution validation script and verified that the non-main dispatch includes an unrelated commit while explicit main checkout excludes it.
- Ran the focused workflow validation script and reviewed the mutable-action and credential-exposure validation log.
- T-Rex produced proof for a posted P1 finding and documented the corresponding review comment.
- Validated the non-main ref PR base with before and after state logs and the reproduction script, showing the before state included the unrelated change and the after state confirms the explicit-main checkout excludes it.
- Ran the mutable actions validation script and inspected the log, which shows privileged tokens and write permissions were present in the workflow run.

<a href="https://app.greptile.com/trex/runs/17422512/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Ftolgee-sync.yml%3A21-25%0A**Manual%20dispatch%20inherits%20the%20selected%20ref**%0A%0A%60workflow_dispatch%60%20lets%20a%20maintainer%20start%20this%20workflow%20from%20a%20non-%60main%60%20ref%2C%20and%20checkout%20defaults%20to%20that%20selected%20ref%20because%20no%20%60ref%60%20is%20configured.%20The%20script%20then%20creates%20%60tolgee-sync%2F...%60%20from%20the%20current%20checkout%20but%20opens%20the%20pull%20request%20against%20%60main%60%20at%20lines%2055%E2%80%9358.%20A%20translation%20PR%20can%20therefore%20include%20unrelated%20commits%20from%20the%20selected%20ref%20or%20conflict%20with%20%60main%60.%20Explicitly%20check%20out%20%60main%60%20before%20creating%20the%20sync%20branch.%0A%0A%23%23%23%20Issue%202%0A.github%2Fworkflows%2Ftolgee-sync.yml%3A22-27%0A**Privileged%20actions%20use%20mutable%20tags**%0A%0A%60actions%2Fcheckout%40v7%60%20and%20%60pnpm%2Fsetup%40v2%60%20are%20movable%20version%20tags%20rather%20than%20immutable%20commit%20SHAs.%20This%20job%20has%20repository%20write%20permissions%20and%20provides%20%60WOLFSTAR_TOKEN%60%20to%20checkout%20and%20GitHub%20commands%2C%20as%20well%20as%20%60TOLGEE_API_KEY%60%20to%20the%20translation%20pull.%20If%20either%20upstream%20tag%20moves%2C%20different%20code%20can%20run%20with%20those%20credentials.%20Pin%20both%20actions%20to%20reviewed%20full-length%20commit%20SHAs.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=wolfstar-project%2Fwolfstar&pr=235&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0A.github%2Fworkflows%2Ftolgee-sync.yml%3A21-25%0A**Manual%20dispatch%20inherits%20the%20selected%20ref**%0A%0A%60workflow_dispatch%60%20lets%20a%20maintainer%20start%20this%20workflow%20from%20a%20non-%60main%60%20ref%2C%20and%20checkout%20defaults%20to%20that%20selected%20ref%20because%20no%20%60ref%60%20is%20configured.%20The%20script%20then%20creates%20%60tolgee-sync%2F...%60%20from%20the%20current%20checkout%20but%20opens%20the%20pull%20request%20against%20%60main%60%20at%20lines%2055%E2%80%9358.%20A%20translation%20PR%20can%20therefore%20include%20unrelated%20commits%20from%20the%20selected%20ref%20or%20conflict%20with%20%60main%60.%20Explicitly%20check%20out%20%60main%60%20before%20creating%20the%20sync%20branch.%0A%0A%23%23%23%20Issue%202%0A.github%2Fworkflows%2Ftolgee-sync.yml%3A22-27%0A**Privileged%20actions%20use%20mutable%20tags**%0A%0A%60actions%2Fcheckout%40v7%60%20and%20%60pnpm%2Fsetup%40v2%60%20are%20movable%20version%20tags%20rather%20than%20immutable%20commit%20SHAs.%20This%20job%20has%20repository%20write%20permissions%20and%20provides%20%60WOLFSTAR_TOKEN%60%20to%20checkout%20and%20GitHub%20commands%2C%20as%20well%20as%20%60TOLGEE_API_KEY%60%20to%20the%20translation%20pull.%20If%20either%20upstream%20tag%20moves%2C%20different%20code%20can%20run%20with%20those%20credentials.%20Pin%20both%20actions%20to%20reviewed%20full-length%20commit%20SHAs.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=235&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor-cloud?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22wolfstar-project%2Fwolfstar%22%20on%20the%20existing%20branch%20%22ci%2Ftolgee-sync-workflow%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22ci%2Ftolgee-sync-workflow%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Ftolgee-sync.yml%3A21-25%0A**Manual%20dispatch%20inherits%20the%20selected%20ref**%0A%0A%60workflow_dispatch%60%20lets%20a%20maintainer%20start%20this%20workflow%20from%20a%20non-%60main%60%20ref%2C%20and%20checkout%20defaults%20to%20that%20selected%20ref%20because%20no%20%60ref%60%20is%20configured.%20The%20script%20then%20creates%20%60tolgee-sync%2F...%60%20from%20the%20current%20checkout%20but%20opens%20the%20pull%20request%20against%20%60main%60%20at%20lines%2055%E2%80%9358.%20A%20translation%20PR%20can%20therefore%20include%20unrelated%20commits%20from%20the%20selected%20ref%20or%20conflict%20with%20%60main%60.%20Explicitly%20check%20out%20%60main%60%20before%20creating%20the%20sync%20branch.%0A%0A%23%23%23%20Issue%202%0A.github%2Fworkflows%2Ftolgee-sync.yml%3A22-27%0A**Privileged%20actions%20use%20mutable%20tags**%0A%0A%60actions%2Fcheckout%40v7%60%20and%20%60pnpm%2Fsetup%40v2%60%20are%20movable%20version%20tags%20rather%20than%20immutable%20commit%20SHAs.%20This%20job%20has%20repository%20write%20permissions%20and%20provides%20%60WOLFSTAR_TOKEN%60%20to%20checkout%20and%20GitHub%20commands%2C%20as%20well%20as%20%60TOLGEE_API_KEY%60%20to%20the%20translation%20pull.%20If%20either%20upstream%20tag%20moves%2C%20different%20code%20can%20run%20with%20those%20credentials.%20Pin%20both%20actions%20to%20reviewed%20full-length%20commit%20SHAs.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.&repo=wolfstar-project%2Fwolfstar&uid=108079&ts=1785931896&sig=620146eded90085d4f2a29268086a3083aa9088203c6c054133aec4bb18915ac&pr=235&platform=github&fid=d2c764d3-4753-4005-8d67-bf30dab6222b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloudDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"><img alt="Fix All in Cursor Cloud Agents" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorCloud.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/tolgee-sync.yml:21-25
**Manual dispatch inherits the selected ref**

`workflow_dispatch` lets a maintainer start this workflow from a non-`main` ref, and checkout defaults to that selected ref because no `ref` is configured. The script then creates `tolgee-sync/...` from the current checkout but opens the pull request against `main` at lines 55–58. A translation PR can therefore include unrelated commits from the selected ref or conflict with `main`. Explicitly check out `main` before creating the sync branch.

### Issue 2
.github/workflows/tolgee-sync.yml:22-27
**Privileged actions use mutable tags**

`actions/checkout@v7` and `pnpm/setup@v2` are movable version tags rather than immutable commit SHAs. This job has repository write permissions and provides `WOLFSTAR_TOKEN` to checkout and GitHub commands, as well as `TOLGEE_API_KEY` to the translation pull. If either upstream tag moves, different code can run with those credentials. Pin both actions to reviewed full-length commit SHAs.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci(i18n): add scheduled Tolgee translati..."](https://github.com/wolfstar-project/wolfstar/commit/509ea3221f2b64f7d4be8e753a394cd12ce41ea5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50413479)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->